### PR TITLE
Ordnance Survey Places geocoder plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ There are two default bundle types, address and area.
 
 There is [an overview of the bundles and reusing addresses on the wiki](https://github.com/localgovdrupal/localgov_geo/wiki/Locations-Module-(LocalGov-Geo)).
 
+## Ordnance Survey Places geocoder
+This module provides a Drupal geocoder plugin for the [Ordnance Survey Places PHP geocoder](https://packagist.org/packages/localgovdrupal/localgov_os_places_geocoder_provider).  This plugin is useful for geocoding and address lookup using the [Ordnance Survey Places API](https://osdatahub.os.uk/docs/places/overview) which covers addresses in the UK.  This plugin requires an API key.  It is free for UK local authorities.
+
+### Good to know
+- Install the [Ordnance Survey Places PHP geocoder](https://packagist.org/packages/localgovdrupal/localgov_os_places_geocoder_provider) to use this plugin as per the composer suggestion.
+- There is a [known issue](https://www.drupal.org/project/geocoder/issues/3153678#comment-14203727) with Drupal geocoder plugins that they sometimes do not immediately appear in the *Geocoder provider* dropdown at /admin/config/system/geocoder/geocoder-provider.  If this happens, restart PHP or the (virtual) machine hosting PHP and then review the dropdown.

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     },
     "require-dev": {
         "localgovdrupal/localgov_core": "^2.1"
+    },
+    "suggest": {
+        "localgovdrupal/localgov_os_places_geocoder_provider": "1.x-dev"
     }
 }

--- a/config/schema/localgov_geo.geocoder.schema.yml
+++ b/config/schema/localgov_geo.geocoder.schema.yml
@@ -1,0 +1,20 @@
+geocoder_provider.configuration.localgov_os_places:
+  type: geocoder_provider_configuration
+  label: 'Localgov OS Places arguments'
+  mapping:
+    genericAddressQueryUrl:
+      type: string
+      label: 'Street address-based query URL'
+      description: 'URL of the OS Places API server for street address-based query.'
+    postcodeQueryUrl:
+      type: string
+      label: 'Postcode-based query URL'
+      description: 'URL of the OS Places API server for postcode-based query.'
+    apiKey:
+      type: string
+      label: 'API key'
+      description: 'Value of the API key'
+    userAgent:
+      type: string
+      label: 'User agent'
+      description: 'Value of the User-Agent header'

--- a/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
+++ b/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\localgov_geo\Plugin\Geocoder\Provider;
+
+use Drupal\geocoder\ConfigurableProviderUsingHandlerWithAdapterBase;
+
+/**
+ * Provides an Ordnance Survey Places API-based geocoder provider plugin.
+ *
+ * @GeocoderProvider(
+ *   id        = "localgov_os_places",
+ *   name      = "Localgov OS Places",
+ *   handler   = "\LocalgovDrupal\OsPlacesGeocoder\Provider\LocalgovOsPlacesGeocoder",
+ *   arguments = {
+ *     "genericAddressQueryUrl" = "https://api.os.uk/search/places/v1/find",
+ *     "postcodeQueryUrl"       = "https://api.os.uk/search/places/v1/postcode",
+ *     "apiKey"                 = "",
+ *     "userAgent"              = "LocalGov Drupal"
+ *   }
+ * )
+ */
+class LocalgovOsPlacesGeocoder extends configurableProviderUsingHandlerWithAdapterBase {}

--- a/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
+++ b/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
@@ -12,7 +12,7 @@ use Drupal\geocoder\ConfigurableProviderUsingHandlerWithAdapterBase;
  * @GeocoderProvider(
  *   id        = "localgov_os_places",
  *   name      = "Localgov OS Places",
- *   handler   = "\LocalgovDrupal\OsPlacesGeocoder\Provider\LocalgovOsPlacesGeocoder",
+ *   handler   = "\LocalgovDrupal\OsPlacesGeocoder\Provider\OsPlacesGeocoder",
  *   arguments = {
  *     "genericAddressQueryUrl" = "https://api.os.uk/search/places/v1/find",
  *     "postcodeQueryUrl"       = "https://api.os.uk/search/places/v1/postcode",


### PR DESCRIPTION
This is a plugin for Drupal's Geocoder module.  Useful for UK address lookup.

I am bringing these files from the [localgov_forms module](https://github.com/localgovdrupal/localgov_forms/pull/7).  This one is blocked by [another pull request](https://github.com/localgovdrupal/localgov_os_places_geocoder_provider/pull/1) for the newly created **localgovdrupal/localgov_os_places_geocoder_provider** composer package.

## Test steps (for now)
```
$ composer require localgovdrupal/localgov_geo:'dev-feature/os-places-geocoder-plugin as 1.1.1'
$ composer require --dev localgovdrupal/localgov_os_places_geocoder_provider:dev-feature/provider
$ drush -y en geocoder localgov_geo
```
Now add the **Localgov OS Places** Geocoder plugin from */admin/config/system/geocoder/geocoder-provider*.  This step, unfortunately, asks for an API key.

I am marking this pull request as *Draft* until localgovdrupal/localgov_os_places_geocoder_provider is ready.