### PR TITLE
Fix #91. Don't re-run updates on sites with config in their sync folder.

### DIFF
--- a/modules/localgov_geo_update/localgov_geo_update.deploy.php
+++ b/modules/localgov_geo_update/localgov_geo_update.deploy.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Hook_deploy_NAME() implementations.
+ *
+ * These are executed towards the end of `drush deploy`.
+ */
+
+use Drupal\geo_entity\Entity\GeoEntity;
+
+/**
+ * Recreates localgov_geo as geo entities.
+ */
+function localgov_geo_update_deploy_geo_entity_conversion(array &$sandbox) {
+  // Set up the batch by retrieving all of the IDs.
+  $storage = \Drupal::entityTypeManager()->getStorage('localgov_geo');
+  if (!isset($sandbox['progress'])) {
+    $sandbox['ids'] = $storage->getQuery()->accessCheck(FALSE)->execute();
+    $sandbox['max'] = count($sandbox['ids']);
+    $sandbox['progress'] = 0;
+  }
+
+  // Try to update 25 entities at a time.
+  $ids = array_slice($sandbox['ids'], $sandbox['progress'], 25);
+
+  foreach ($storage->loadMultiple($ids) as $entity) {
+    $geo = GeoEntity::create($entity->toArray());
+    $geo->save();
+    $entity->delete();
+    $sandbox['progress']++;
+  }
+
+  // Try to update the percentage but avoid division by zero.
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+
+  // Show a status update for the current progress.
+  return t("Updated the label for @progress out of @max geo entities.", [
+    '@progress' => $sandbox['progress'],
+    '@max' => $sandbox['max'],
+  ]);
+}

--- a/modules/localgov_geo_update/localgov_geo_update.install
+++ b/modules/localgov_geo_update/localgov_geo_update.install
@@ -18,25 +18,51 @@ use Drupal\views\Entity\View;
 function localgov_geo_update_update_8001() {
   $enabled = [];
   $module_handler = \Drupal::service('module_handler');
-  $module_installer = \Drupal::service('module_installer');
-  $module_installer->install(['geo_entity']);
-  $enabled[] = \t('Geo entity');
+  $enabled['geo_entity'] = \t('Geo entity');
   if ($module_handler->moduleExists('localgov_geo_address')) {
-    $module_installer->install(['geo_entity_address']);
-    $enabled[] = \t('Geo entity: address');
+    $enabled['geo_entity_address'] = \t('Geo entity: address');
   }
   if ($module_handler->moduleExists('localgov_geo_area')) {
-    $module_installer->install(['geo_entity_area']);
-    $enabled[] = \t('Geo entity: area');
+    $enabled['geo_entity_area'] = \t('Geo entity: area');
   }
 
-  return t("Enabled @modules.", ['@modules' => implode(', ', $enabled)]);
+  // Have the localgov_geo_update updates run on an another environment and
+  // been exported to config sync that is going to be imported?
+  // If you want to force a value, to run or not, set the state before running
+  // this update.
+  //
+  // @see https://github.com/localgovdrupal/localgov_geo/issues/91
+  $update_state = \Drupal::state()->get('localgov_geo_update.run', NULL);
+  if (is_null($update_state)) {
+    $sync = \Drupal::service('config.storage.sync')->read('core.extension');
+    $sync_modules = array_keys($sync['module']);
+    if (count(array_intersect($sync_modules, array_keys($enabled))) == count($enabled)) {
+      $update_state = TRUE;
+      \Drupal::state()->set('localgov_geo_update.run', $update_state);
+    }
+  }
+
+  if ($update_state !== TRUE) {
+    $module_installer = \Drupal::service('module_installer');
+    $module_installer->install(array_keys($enabled));
+    return t("Enabled @modules.", ['@modules' => implode(', ', $enabled)]);
+  }
+  else {
+    return t("Skipping LocalGov Geo Updates:
+      It is detected you have already run these and exported configuration to config sync.
+      Run config import and the new configuration will be on this instance also.
+      If you are using drush deploy the localgov geo entities will be updated too.
+      If you are manually deploying after importing configuration run drush deploy:hook");
+  }
 }
 
 /**
  * Ensure equivalent geo_entity bundles to localgov_geo.
  */
 function localgov_geo_update_update_8002() {
+  if (\Drupal::state()->get('localgov_geo_update.run', FALSE)) {
+    return t('Skipped: See message localgov_geo_update_update_8001.');
+  }
   $localgov_storage = \Drupal::entityTypeManager()->getStorage('localgov_geo_type');
   $geo_storage = \Drupal::entityTypeManager()->getStorage('geo_entity_type');
   foreach ($localgov_storage->loadMultiple() as $localgov_type) {
@@ -65,6 +91,9 @@ function localgov_geo_update_update_8002() {
  * Ensure geo_entity bundles have fields of localgov_geo.
  */
 function localgov_geo_update_update_8003() {
+  if (\Drupal::state()->get('localgov_geo_update.run', FALSE)) {
+    return t('Skipped: See message localgov_geo_update_update_8001.');
+  }
   $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
   $field_config = \Drupal::entityTypeManager()->getStorage('field_config');
   foreach ($field_storage->loadByProperties(['entity_type' => 'localgov_geo']) as $lgd_field) {
@@ -115,6 +144,9 @@ function localgov_geo_update_update_8003() {
  * Recreate localgov_geo as geo entities.
  */
 function localgov_geo_update_update_8004(&$sandbox) {
+  if (\Drupal::state()->get('localgov_geo_update.run', FALSE)) {
+    return t('Skipped: See message localgov_geo_update_update_8001.');
+  }
   // Set up the batch by retrieving all of the IDs.
   $storage = \Drupal::entityTypeManager()->getStorage('localgov_geo');
   if (!isset($sandbox['progress'])) {
@@ -147,6 +179,9 @@ function localgov_geo_update_update_8004(&$sandbox) {
  * Update reference fields to use geo_entity and its library browser.
  */
 function localgov_geo_update_update_8005() {
+  if (\Drupal::state()->get('localgov_geo_update.run', FALSE)) {
+    return t('Skipped: See message localgov_geo_update_update_8001.');
+  }
   $fields = [];
   $storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
   foreach ($storage->loadMultiple() as $field) {
@@ -193,14 +228,20 @@ function localgov_geo_update_update_8005() {
  * Update the entity browser library.
  */
 function localgov_geo_update_update_8806() {
+  if (\Drupal::state()->get('localgov_geo_update.run', FALSE)) {
+    return t('Skipped: See message localgov_geo_update_update_8001.');
+  }
   $view = View::load('localgov_geo_library');
-  $view->delete();
+  $view?->delete();
 }
 
 /**
  * Update views fields.
  */
 function localgov_geo_update_update_8807() {
+  if (\Drupal::state()->get('localgov_geo_update.run', FALSE)) {
+    return t('Skipped: See message localgov_geo_update_update_8001.');
+  }
   $views = View::loadMultiple();
   foreach ($views as $view) {
     $altered = FALSE;


### PR DESCRIPTION
Add drush deploy function to automatically or manually update content entities after configuration has been sync'd.