### PR TITLE
Config schema for the LocalGov OS Places address lookup plugin

### DIFF
--- a/config/schema/localgov_geo.schema.yml
+++ b/config/schema/localgov_geo.schema.yml
@@ -1,0 +1,36 @@
+# Config schema definitions for the localgov_geo module.
+
+# Schema for the localgov_os_places plugin.
+geocoder_provider.configuration.localgov_os_places:
+  type: mapping
+  label: 'Plugin arguments for the LocalGov OS Places plugin'
+  mapping:
+    apiKey:
+      type: string
+      label: 'API key'
+      description: 'As it says on the tin.'
+    genericAddressQueryUrl:
+      type: string
+      label: 'Address lookup URL'
+      description: 'REST API endpoint for address lookup.  Works for both street names and postcodes.'
+    postcodeQueryUrl:
+      type: string
+      label: 'Postcode-based address lookup URL'
+      description: 'REST API endpoint for address lookup by postcode.'
+    throttle:
+      type: mapping
+      label: 'Throttle'
+      nullable: true
+      mapping:
+        period:
+          type: integer
+          label: 'Period'
+          description: 'Period of time for which the number of requests is limited, in seconds.'
+        limit:
+          type: integer
+          label: 'Limit'
+          description: 'Maximum number of requests allowed for the given period.'
+    userAgent:
+      type: string
+      label: 'User agent name'
+      description: 'As it says on the tin.'

--- a/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
+++ b/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
@@ -11,7 +11,7 @@ use Drupal\geocoder\ConfigurableProviderUsingHandlerWithAdapterBase;
  *
  * @GeocoderProvider(
  *   id        = "localgov_os_places",
- *   name      = "Localgov OS Places",
+ *   name      = "LocalGov OS Places",
  *   handler   = "\LocalgovDrupal\OsPlacesGeocoder\Provider\OsPlacesGeocoder",
  *   arguments = {
  *     "genericAddressQueryUrl" = "https://api.os.uk/search/places/v1/find",


### PR DESCRIPTION
Config schema declaration for the localgov_os_places address lookup plugin.  The config form for this plugin no longer works without this schema declaration.

Without the schema declaration, the following error message shows up at `/admin/config/system/geocoder/geocoder-provider/manage/localgov_os_places`:
`No configurations options requested for this Provider: The arguments defined in the plugin annotation do not match the arguments defined in the config schema.`