### PR TITLE
Assign and update geo entity browser permissions

### DIFF
--- a/localgov_geo.module
+++ b/localgov_geo.module
@@ -18,10 +18,12 @@ function localgov_geo_localgov_roles_default() {
       'create geo',
       'delete geo',
       'edit geo',
+      'access geo_entity_library entity browser pages',
     ],
     // @codingStandardsIgnoreLine
     \Drupal\localgov_roles\RolesHelper::AUTHOR_ROLE => [
       'create geo',
+      'access geo_entity_library entity browser pages',
     ],
   ];
 }

--- a/modules/localgov_geo_update/localgov_geo_update.install
+++ b/modules/localgov_geo_update/localgov_geo_update.install
@@ -11,6 +11,7 @@ use Drupal\field\FieldStorageConfigInterface;
 use Drupal\geo_entity\Entity\GeoEntity;
 use Drupal\geo_entity\Entity\GeoEntityType;
 use Drupal\localgov_geo_update\MigrateDisplayModes;
+use Drupal\user\Entity\Role;
 use Drupal\views\Entity\View;
 
 /**
@@ -290,5 +291,30 @@ function localgov_geo_update_update_8808() {
   foreach ($form_mode_ids as $form_mode_id) {
     [$bundle, $name] = array_slice(explode('.', $form_mode_id, 3), 1, 2);
     MigrateDisplayModes::migrate($bundle, 'form', $name);
+  }
+}
+
+/**
+ * Update permission for the geo entity browser from localgov_geo.
+ *
+ * This grants the access geo_entity_library entity browser permission for roles
+ * which had the access localgov_geo_library entity browser pages permission
+ * during the update, before this permission in stripped as part of the user
+ * role update.
+ *
+ * Note: this only applies to users upgrading from Drupal 9. If you have already
+ * updated you will need to reassign this permission manually.
+ */
+function localgov_geo_update_update_8809() {
+  $role_ids = \Drupal::entityTypeManager()->getStorage('user_role')
+    ->getQuery()
+    ->execute();
+  if (!empty($role_ids)) {
+    $roles = Role::loadMultiple($role_ids);
+    foreach ($roles as $role) {
+      if ($role->hasPermission('access localgov_geo_library entity browser pages')) {
+        $role->grantPermission('access geo_entity_library entity browser pages');
+      }
+    }
   }
 }

--- a/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/entity_browser.browser.localgov_geo_library.yml
+++ b/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/entity_browser.browser.localgov_geo_library.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.localgov_geo_library
+  module:
+    - entity_browser_entity_form
+    - views
+name: localgov_geo_library
+label: 'Geo Browser'
+display: modal
+display_configuration:
+  width: '1200'
+  height: '800'
+  link_text: 'Select location'
+  auto_open: false
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: tabs
+widget_selector_configuration: {  }
+widgets:
+  d5750416-1d97-43b9-95b1-f843724c8ecd:
+    settings:
+      submit_text: 'Select location'
+      auto_select: false
+      view: localgov_geo_library
+      view_display: entity_browser_1
+    uuid: d5750416-1d97-43b9-95b1-f843724c8ecd
+    weight: 1
+    label: 'Search existing locations'
+    id: view
+  3edf0a0f-cb61-4324-8d36-1898e23a16ed:
+    settings:
+      submit_text: 'Save address'
+      entity_type: localgov_geo
+      bundle: address
+      form_mode: inline
+    uuid: 3edf0a0f-cb61-4324-8d36-1898e23a16ed
+    weight: 2
+    label: 'Create new address'
+    id: entity_form
+  beda8d11-9000-4069-95e7-dbb4282941db:
+    settings:
+      submit_text: 'Save area'
+      entity_type: localgov_geo
+      bundle: area
+      form_mode: inline
+    uuid: beda8d11-9000-4069-95e7-dbb4282941db
+    weight: 3
+    label: 'Create new area'
+    id: entity_form

--- a/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/entity_browser.browser.localgov_geo_library.yml
+++ b/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/entity_browser.browser.localgov_geo_library.yml
@@ -18,34 +18,40 @@ selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: tabs
 widget_selector_configuration: {  }
-widgets:
-  d5750416-1d97-43b9-95b1-f843724c8ecd:
-    settings:
-      submit_text: 'Select location'
-      auto_select: false
-      view: localgov_geo_library
-      view_display: entity_browser_1
-    uuid: d5750416-1d97-43b9-95b1-f843724c8ecd
-    weight: 1
-    label: 'Search existing locations'
-    id: view
-  3edf0a0f-cb61-4324-8d36-1898e23a16ed:
-    settings:
-      submit_text: 'Save address'
-      entity_type: localgov_geo
-      bundle: address
-      form_mode: inline
-    uuid: 3edf0a0f-cb61-4324-8d36-1898e23a16ed
-    weight: 2
-    label: 'Create new address'
-    id: entity_form
-  beda8d11-9000-4069-95e7-dbb4282941db:
-    settings:
-      submit_text: 'Save area'
-      entity_type: localgov_geo
-      bundle: area
-      form_mode: inline
-    uuid: beda8d11-9000-4069-95e7-dbb4282941db
-    weight: 3
-    label: 'Create new area'
-    id: entity_form
+widgets: {  }
+  # Commented out below for the purpose of the test, otherwise the error
+  # 'Call to a member function getConfigDependencyKey() on null' is triggered
+  # @See https://www.drupal.org/project/entity_browser/issues/2845037
+  # Since we're only testing the permission is updated, it's not really an issue
+  # for our purposes.
+  #
+  # d5750416-1d97-43b9-95b1-f843724c8ecd:
+  #   settings:
+  #     submit_text: 'Select location'
+  #     auto_select: false
+  #     view: localgov_geo_library
+  #     view_display: entity_browser_1
+  #   uuid: d5750416-1d97-43b9-95b1-f843724c8ecd
+  #   weight: 1
+  #   label: 'Search existing locations'
+  #   id: view
+  # 3edf0a0f-cb61-4324-8d36-1898e23a16ed:
+  #   settings:
+  #     submit_text: 'Save address'
+  #     entity_type: localgov_geo
+  #     bundle: address
+  #     form_mode: inline
+  #   uuid: 3edf0a0f-cb61-4324-8d36-1898e23a16ed
+  #   weight: 2
+  #   label: 'Create new address'
+  #   id: entity_form
+  # beda8d11-9000-4069-95e7-dbb4282941db:
+  #   settings:
+  #     submit_text: 'Save area'
+  #     entity_type: localgov_geo
+  #     bundle: area
+  #     form_mode: inline
+  #   uuid: beda8d11-9000-4069-95e7-dbb4282941db
+  #   weight: 3
+  #   label: 'Create new area'
+  #   id: entity_form

--- a/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/views.view.localgov_geo_library.yml
+++ b/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/views.view.localgov_geo_library.yml
@@ -1,0 +1,267 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_browser
+    - localgov_geo
+id: localgov_geo_library
+label: 'Geo library'
+module: views
+description: ''
+tag: ''
+base_table: localgov_geo_field_data
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        entity_browser_select:
+          id: entity_browser_select
+          table: localgov_geo
+          field: entity_browser_select
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          use_field_cardinality: false
+          entity_type: localgov_geo
+          plugin_id: entity_browser_select
+        label:
+          table: localgov_geo_field_data
+          field: label
+          id: label
+          entity_type: null
+          entity_field: label
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        label:
+          id: label
+          table: localgov_geo_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: label_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: label_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: label
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              localgov_editor: '0'
+              localgov_author: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: localgov_geo
+          entity_field: label
+          plugin_id: string
+      sorts: {  }
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+      tags: {  }
+  entity_browser_1:
+    display_plugin: entity_browser
+    id: entity_browser_1
+    display_title: 'Entity browser'
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+      tags: {  }

--- a/modules/localgov_geo_update/tests/src/Functional/UpdateLocalgovGeoTest.php
+++ b/modules/localgov_geo_update/tests/src/Functional/UpdateLocalgovGeoTest.php
@@ -44,6 +44,7 @@ class UpdateLocalgovGeoTest extends BrowserTestBase {
     'create geo',
     'edit geo',
     'administer geo types',
+    'access localgov_geo_library entity browser pages',
   ];
 
   /**
@@ -201,9 +202,14 @@ class UpdateLocalgovGeoTest extends BrowserTestBase {
     // plugin it is using.
     $simple_address_form_view = EntityFormDisplay::load('geo_entity.simple_address.default');
     $form_display_fields = $simple_address_form_view->get('content');
-    // var_dump($form_display_fields);
     // $this->drupalGet('admin/content/geo/add/simple_address');
     $this->assertEquals('geo_entity_address', $form_display_fields['postal_address']['type']);
+
+    // Run the entity browser update.
+    localgov_geo_update_update_8809();
+
+    // Check user can access geo entitiy browser.
+    $this->assertTrue($this->adminUser->hasPermission('access geo_entity_library entity browser pages'));
   }
 
 }

--- a/modules/localgov_geo_update/tests/src/Functional/UpdateLocalgovGeoTest.php
+++ b/modules/localgov_geo_update/tests/src/Functional/UpdateLocalgovGeoTest.php
@@ -26,11 +26,13 @@ class UpdateLocalgovGeoTest extends BrowserTestBase {
     'system',
     'text',
     'field_ui',
+    'entity_browser',
+    'views',
     'localgov_geo',
     'localgov_geo_update',
-    'localgov_geo_update_to_geo_test',
     'geo_entity',
     'token',
+    'localgov_geo_update_to_geo_test',
   ];
 
   /**


### PR DESCRIPTION
Fix #103 

- Add access geo_entitiy browser to editor and author roles
- Add update hook for localgov_geo to geo_entity entity browser
- Update the localgov_geo test to demonstrate the permission is granted.
