### PR TITLE
Feature: Local custodian code support for OS Places geocoder

### DIFF
--- a/config/schema/localgov_geo.schema.yml
+++ b/config/schema/localgov_geo.schema.yml
@@ -34,3 +34,10 @@ geocoder_provider.configuration.localgov_os_places:
       type: string
       label: 'User agent name'
       description: 'As it says on the tin.'
+    apply_local_custodian_code:
+      type: boolean
+      label: 'Apply local authority filter'
+    local_custodian_code:
+      type: integer
+      label: 'Local custodian code'
+      description: 'Code number for a local authority.  See https://osdatahub.os.uk/docs/match/technicalSpecification.  Leave empty or use 0 for country-wide address search.'

--- a/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
+++ b/src/Plugin/Geocoder/Provider/LocalgovOsPlacesGeocoder.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace Drupal\localgov_geo\Plugin\Geocoder\Provider;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\geocoder\ConfigurableProviderUsingHandlerWithAdapterBase;
+use Geocoder\Query\GeocodeQuery;
 
 /**
  * Provides an Ordnance Survey Places API-based geocoder provider plugin.
@@ -21,4 +23,82 @@ use Drupal\geocoder\ConfigurableProviderUsingHandlerWithAdapterBase;
  *   }
  * )
  */
-class LocalgovOsPlacesGeocoder extends configurableProviderUsingHandlerWithAdapterBase {}
+class LocalgovOsPlacesGeocoder extends configurableProviderUsingHandlerWithAdapterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doGeocode($source) {
+    /** @var string $source */
+    $this->throttle->waitForAvailability($this->pluginId, $this->configuration['throttle'] ?? []);
+
+    $query = GeocodeQuery::create($source)
+      ->withData('local_custodian_code', $this->configuration['local_custodian_code']);
+
+    return $this->getHandlerWrapper()->geocodeQuery($query);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+
+    return [
+      'apply_local_custodian_code' => FALSE,
+      'local_custodian_code' => 0,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Adds the local_custodian_code option.  This option can restrict address
+   * lookup within a certain local authority.
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    // Place the local authority filter settings within the
+    // "Geocoder Additional Options" fieldset.
+    $form['options']['geocoder']['apply_local_custodian_code'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Apply local authority filter'),
+      '#description'   => $this->t('Restricts address search to a single local authority'),
+      '#default_value' => $this->configuration['apply_local_custodian_code'],
+      '#return_value'  => TRUE,
+    ];
+
+    $form['options']['geocoder']['local_custodian_code'] = [
+      '#type'          => 'number',
+      '#title'         => $this->t('Local custodian code'),
+      '#description' => $this->t('Code number for a local authority.  See https://osdatahub.os.uk/docs/match/technicalSpecification.  Leave empty or use 0 for country-wide address search.  Note that this can be overridden by users of this plugin such as the LocalGov address lookup Webform element.'),
+      '#min'           => 0,
+      '#default_value' => $this->configuration['local_custodian_code'],
+      '#states'        => [
+        'visible' => [
+          ':input[name="apply_local_custodian_code"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+
+    parent::submitConfigurationForm($form, $form_state);
+
+    $this->configuration['apply_local_custodian_code'] = $form_state->getValue('apply_local_custodian_code');
+    if ($this->configuration['apply_local_custodian_code']) {
+      $this->configuration['local_custodian_code'] = $form_state->getValue('local_custodian_code');
+    }
+    else {
+      $this->configuration['local_custodian_code'] = 0;
+    }
+  }
+
+}


### PR DESCRIPTION
Draft pull request.  Ekes has raised a related [pull request](https://www.drupal.org/project/geocoder/issues/3406303) that may simplify this one.

The local custodian code is a numeric code used by the [OS Places API](https://osdatahub.os.uk/docs/match/technicalSpecificatio).  Every local authority has been assigned a [code](https://www.ordnancesurvey.co.uk/documents/product-support/support/addressbase-local-custodian-codes.zip).  This change extends the localgov_os_places geocoder to filter results based on a given local custodian code.