### PR TITLE
Fixes test failures enabling modules.

### DIFF
--- a/localgov_geo.install
+++ b/localgov_geo.install
@@ -11,6 +11,13 @@ use Drupal\user\RoleInterface;
  * Implements hook_install().
  */
 function localgov_geo_install() {
+  // When permissions are set the PermissionHandler rebuilds the permissions.
+  // This causes the filter module should it be enabled to create a url from
+  // one of its paths https://git.drupalcode.org/project/drupal/-/blob/81ff548f6ff6e819b111fe99537b566f25f80c4f/core/modules/filter/src/FilterPermissions.php#L56
+  // If this module and filter module are being enabled in the same
+  // ModuleInstaller call, as happens at least in some tests, the route while
+  // declared is not yet in the route cache.
+  \Drupal::service('router.builder')->rebuild();
   // So node.module says don't do this. Media then just does it.
   // Working assumption here is that exposing geo information is the intention.
   // Otherwise we could push this into the localgov profile. However, it not


### PR DESCRIPTION
Probably a marginal one this, and only (?) in tests, but I can't think of a better fix than this.

The issue reported in https://github.com/localgovdrupal/localgov_microsites_group/issues/464#issuecomment-2118905519 caused by rebuilding the permissions before the route cache was cleared
```
1) Drupal\Tests\localgov_microsites_group\Functional\GroupContentTypeAccessTest::testGroupAdminAccess
Symfony\Component\Routing\Exception\RouteNotFoundException: Route "entity.filter_format.edit_form" does not exist.

/var/www/html/web/core/lib/Drupal/Core/Routing/RouteProvider.php:206
/var/www/html/web/core/lib/Drupal/Core/Routing/UrlGenerator.php:443
/var/www/html/web/core/lib/Drupal/Core/Routing/UrlGenerator.php:276
/var/www/html/web/core/lib/Drupal/Core/Render/MetadataBubblingUrlGenerator.php:108
/var/www/html/web/core/lib/Drupal/Core/Url.php:765
/var/www/html/web/core/modules/filter/src/FilterPermissions.php:56
/var/www/html/web/core/modules/user/src/PermissionHandler.php:153
/var/www/html/web/core/modules/user/src/PermissionHandler.php:112
/var/www/html/web/core/modules/user/src/Entity/Role.php:203
/var/www/html/web/core/lib/Drupal/Core/Config/Entity/ConfigEntityBase.php:321
/var/www/html/web/core/modules/user/src/Entity/Role.php:179
/var/www/html/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php:528
/var/www/html/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php:483
/var/www/html/web/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php:257
/var/www/html/web/core/lib/Drupal/Core/Entity/EntityBase.php:354
/var/www/html/web/core/lib/Drupal/Core/Config/Entity/ConfigEntityBase.php:609
/var/www/html/web/core/modules/user/user.module:1004
/var/www/html/web/modules/contrib/localgov_geo/localgov_geo.install:21
/var/www/html/web/core/lib/Drupal/Core/Extension/ModuleHandler.php:400
/var/www/html/web/core/lib/Drupal/Core/Extension/ModuleInstaller.php:364
/var/www/html/web/core/lib/Drupal/Core/ProxyClass/Extension/ModuleInstaller.php:83
/var/www/html/web/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php:475
/var/www/html/web/core/tests/Drupal/Tests/BrowserTestBase.php:561
/var/www/html/web/core/tests/Drupal/Tests/BrowserTestBase.php:369
/var/www/html/web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupContentTypeAccessTest.php:75
/var/www/html/vendor/phpunit/phpunit/src/Framework/TestResult.php:729
```