### PR TITLE
Issue 113: Granting 'create geo' and 'access geo_entity_library entity browser pages'  permissions

### DIFF
--- a/localgov_geo.install
+++ b/localgov_geo.install
@@ -41,8 +41,8 @@ function localgov_geo_update_last_removed() {
 }
 
 /**
- * Grant 'access geo_entity_library entity browser pages' permission to editor,
- * author and contributor roles.
+ * Grant 'create geo' and 'access geo_entity_library entity browser pages'
+ * permissions to Editor, Author and Contributor roles.
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */

--- a/localgov_geo.install
+++ b/localgov_geo.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the localgov_geo module.
  */
 
+use Drupal\localgov_roles\RolesHelper;
+use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 
 /**
@@ -36,4 +38,24 @@ function localgov_geo_install() {
 function localgov_geo_update_last_removed() {
   // Removed all pre-Drupal 10 hooks that updated things now in geo_entity.
   return 8810;
+}
+
+/**
+ * Grant 'access geo_entity_library entity browser pages' permission to editor,
+ * author and contributor roles.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function localgov_geo_update_10001() {
+  $roles = Role::loadMultiple([
+    RolesHelper::EDITOR_ROLE,
+    RolesHelper::AUTHOR_ROLE,
+    RolesHelper::CONTRIBUTOR_ROLE,
+  ]);
+
+  foreach ($roles as $role) {
+    $role->grantPermission('create geo');
+    $role->grantPermission('access geo_entity_library entity browser pages');
+    $role->save();
+  }
 }

--- a/localgov_geo.install
+++ b/localgov_geo.install
@@ -41,7 +41,9 @@ function localgov_geo_update_last_removed() {
 }
 
 /**
- * Grant 'create geo' and 'access geo_entity_library entity browser pages'
+ * Expanding geo permissions.
+ *
+ * Granting 'create geo' and 'access geo_entity_library entity browser pages'
  * permissions to Editor, Author and Contributor roles.
  *
  * @throws \Drupal\Core\Entity\EntityStorageException

--- a/localgov_geo.module
+++ b/localgov_geo.module
@@ -25,6 +25,11 @@ function localgov_geo_localgov_roles_default() {
       'create geo',
       'access geo_entity_library entity browser pages',
     ],
+    // @codingStandardsIgnoreLine
+    \Drupal\localgov_roles\RolesHelper::CONTRIBUTOR_ROLE => [
+      'create geo',
+      'access geo_entity_library entity browser pages',
+    ],
   ];
 }
 


### PR DESCRIPTION
PR for issue https://github.com/localgovdrupal/localgov_geo/issues/113.

Description of changes:

- Adding the 'create geo' and 'access geo_entity_library entity browser pages' permissions to the default set for the Contributor role too, in .localgov_geo.module.
- Update hook in localgov_geo.install: Grant 'create geo' and 'access geo_entity_library entity browser pages' permissions to Editor, Author and Contributor roles.