### PR TITLE
Mark support for Drupal 11 and drop Drupal 9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x
+    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@feature/1.x/d11-support
     with:
       project: 'localgovdrupal/localgov_geo'
       project_path: 'web/modules/contrib/localgov_geo'

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
             },
             "drupal/leaflet": {
                 "Issue #3498789: Update method signatures to not implicitly": "https://git.drupalcode.org/issue/leaflet-3498789/-/commit/a855540e0bc5080e0d9647133f08f80089b3a773.patch"
+            },
+            "commerceguys/addressing": {
+                "Switch implicit nullable types to explict": "https://github.com/commerceguys/addressing/commit/e0fb42455a9a94b7f7f173d530394b420ab5df35.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "homepage": "https://github.com/localgovdrupal/localgov_geo",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/geo_entity": "dev-d11"
+        "drupal/geo_entity": "dev-d11 as 1.0.2"
     },
     "require-dev": {
-        "localgovdrupal/localgov_core": "dev-fix/2.x/246-drupal-11-support"
+        "localgovdrupal/localgov_core": "dev-fix/2.x/246-drupal-11-support as 2.13.11"
     },
     "suggest": {
         "localgovdrupal/localgov_os_places_geocoder_provider": "1.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "patches": {
             "drupal/geofield": {
                 "Nullable types must be explicit": "https://git.drupalcode.org/project/geofield/-/commit/12d1628972669c83e501a3ec9184ae3ad870b58e.diff"
+            },
+            "drupal/leaflet": {
+                "Issue #3498789: Update method signatures to not implicitly": "https://git.drupalcode.org/issue/leaflet-3498789/-/commit/a855540e0bc5080e0d9647133f08f80089b3a773.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "homepage": "https://github.com/localgovdrupal/localgov_geo",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/geo_entity": "^1.0-beta"
+        "drupal/geo_entity": "dev-d11"
     },
     "require-dev": {
-        "localgovdrupal/localgov_core": "^2.12"
+        "localgovdrupal/localgov_core": "dev-fix/2.x/246-drupal-11-support"
     },
     "suggest": {
         "localgovdrupal/localgov_os_places_geocoder_provider": "1.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/localgovdrupal/localgov_geo",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/geo_entity": "dev-d11 as 1.0.2"
+        "drupal/geo_entity": "dev-3493603-drupal-11-support as 1.0.2"
     },
     "require-dev": {
         "localgovdrupal/localgov_core": "dev-fix/2.x/246-drupal-11-support as 2.13.11"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/localgovdrupal/localgov_geo",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/geo_entity": "dev-3493603-drupal-11-support as 1.0.2"
+        "drupal/geo_entity": "^1.0"
     },
     "require-dev": {
         "localgovdrupal/localgov_core": "dev-fix/2.x/246-drupal-11-support as 2.13.11"

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,12 @@
     },
     "suggest": {
         "localgovdrupal/localgov_os_places_geocoder_provider": "1.x-dev"
+    },
+    "extra": {
+        "patches": {
+            "drupal/geofield": {
+                "Nullable types must be explicit": "https://git.drupalcode.org/project/geofield/-/commit/12d1628972669c83e501a3ec9184ae3ad870b58e.diff"
+            }
+        }
     }
 }

--- a/localgov_geo.info.yml
+++ b/localgov_geo.info.yml
@@ -2,6 +2,6 @@ name: LocalGov Geo
 type: module
 description: 'Entity for storing geodata, with location and geocoding.'
 package: LocalGov Drupal
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - geo_entity:geo_entity

--- a/modules/localgov_geo_address/localgov_geo_address.info.yml
+++ b/modules/localgov_geo_address/localgov_geo_address.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Geo Address
 type: module
 description: 'Geo bundle for storing point and address.'
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - localgov_geo:localgov_geo
   - geo_entity:geo_entity_address

--- a/modules/localgov_geo_area/localgov_geo_area.info.yml
+++ b/modules/localgov_geo_area/localgov_geo_area.info.yml
@@ -2,6 +2,6 @@ name: LocalGov Geo Area
 type: module
 description: 'Geo bundle for storing polygons.'
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - geo_entity:geo_entity_area

--- a/modules/localgov_geo_update/localgov_geo_update.info.yml
+++ b/modules/localgov_geo_update/localgov_geo_update.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Geo Update
 type: module
 description: 'Bridging module to Geo Entity.'
 package: LocalGov Drupal
-core_version_requirement: ^9||^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - localgov_geo:localgov_geo
 hidden: true

--- a/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/entity_browser.browser.localgov_geo_library.yml
+++ b/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/config/install/entity_browser.browser.localgov_geo_library.yml
@@ -19,39 +19,39 @@ selection_display_configuration: {  }
 widget_selector: tabs
 widget_selector_configuration: {  }
 widgets: {  }
-  # Commented out below for the purpose of the test, otherwise the error
-  # 'Call to a member function getConfigDependencyKey() on null' is triggered
-  # @See https://www.drupal.org/project/entity_browser/issues/2845037
-  # Since we're only testing the permission is updated, it's not really an issue
-  # for our purposes.
-  #
-  # d5750416-1d97-43b9-95b1-f843724c8ecd:
-  #   settings:
-  #     submit_text: 'Select location'
-  #     auto_select: false
-  #     view: localgov_geo_library
-  #     view_display: entity_browser_1
-  #   uuid: d5750416-1d97-43b9-95b1-f843724c8ecd
-  #   weight: 1
-  #   label: 'Search existing locations'
-  #   id: view
-  # 3edf0a0f-cb61-4324-8d36-1898e23a16ed:
-  #   settings:
-  #     submit_text: 'Save address'
-  #     entity_type: localgov_geo
-  #     bundle: address
-  #     form_mode: inline
-  #   uuid: 3edf0a0f-cb61-4324-8d36-1898e23a16ed
-  #   weight: 2
-  #   label: 'Create new address'
-  #   id: entity_form
-  # beda8d11-9000-4069-95e7-dbb4282941db:
-  #   settings:
-  #     submit_text: 'Save area'
-  #     entity_type: localgov_geo
-  #     bundle: area
-  #     form_mode: inline
-  #   uuid: beda8d11-9000-4069-95e7-dbb4282941db
-  #   weight: 3
-  #   label: 'Create new area'
-  #   id: entity_form
+# Commented out below for the purpose of the test, otherwise the error
+# 'Call to a member function getConfigDependencyKey() on null' is triggered
+# @See https://www.drupal.org/project/entity_browser/issues/2845037
+# Since we're only testing the permission is updated, it's not really an issue
+# for our purposes.
+#
+# d5750416-1d97-43b9-95b1-f843724c8ecd:
+#   settings:
+#     submit_text: 'Select location'
+#     auto_select: false
+#     view: localgov_geo_library
+#     view_display: entity_browser_1
+#   uuid: d5750416-1d97-43b9-95b1-f843724c8ecd
+#   weight: 1
+#   label: 'Search existing locations'
+#   id: view
+# 3edf0a0f-cb61-4324-8d36-1898e23a16ed:
+#   settings:
+#     submit_text: 'Save address'
+#     entity_type: localgov_geo
+#     bundle: address
+#     form_mode: inline
+#   uuid: 3edf0a0f-cb61-4324-8d36-1898e23a16ed
+#   weight: 2
+#   label: 'Create new address'
+#   id: entity_form
+# beda8d11-9000-4069-95e7-dbb4282941db:
+#   settings:
+#     submit_text: 'Save area'
+#     entity_type: localgov_geo
+#     bundle: area
+#     form_mode: inline
+#   uuid: beda8d11-9000-4069-95e7-dbb4282941db
+#   weight: 3
+#   label: 'Create new area'
+#   id: entity_form

--- a/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/localgov_geo_update_to_geo_test.info.yml
+++ b/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/localgov_geo_update_to_geo_test.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Geo Update to Geo test
 description: 'Test update of localgov_geo entity to geo entity'
 type: module
 package: Testing
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
 - address:address

--- a/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/localgov_geo_update_to_geo_test.info.yml
+++ b/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/localgov_geo_update_to_geo_test.info.yml
@@ -5,9 +5,9 @@ package: Testing
 core_version_requirement: ^10 || ^11
 
 dependencies:
-- address:address
-- geofield:geofield
-- geocoder:geocoder
-- geo_entity:geo_entity
-- localgov_geo:localgov_geo
-- localgov_geo:localgov_geo_update
+  - address:address
+  - geofield:geofield
+  - geocoder:geocoder
+  - geo_entity:geo_entity
+  - localgov_geo:localgov_geo
+  - localgov_geo:localgov_geo_update


### PR DESCRIPTION
Running upgrade status highlighted that this module was not compatible with Drupal 11. This pr adds in Drupal 11 support and drops Drupal 9.