### PR TITLE
Removed three patches that have been merged upstream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,5 @@
     },
     "suggest": {
         "localgovdrupal/localgov_os_places_geocoder_provider": "1.x-dev"
-    },
-    "extra": {
-        "patches": {
-            "drupal/geofield": {
-                "Nullable types must be explicit": "https://git.drupalcode.org/project/geofield/-/commit/12d1628972669c83e501a3ec9184ae3ad870b58e.diff"
-            },
-            "drupal/leaflet": {
-                "Issue #3498789: Update method signatures to not implicitly": "https://git.drupalcode.org/issue/leaflet-3498789/-/commit/a855540e0bc5080e0d9647133f08f80089b3a773.patch"
-            },
-            "commerceguys/addressing": {
-                "Switch implicit nullable types to explict": "https://github.com/commerceguys/addressing/commit/e0fb42455a9a94b7f7f173d530394b420ab5df35.patch"
-            }
-        }
     }
 }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?
Checked three patches that were added to this module for 1.0
They are merged upstream so I have removed them

the geofield patch has been merged into dev (see https://www.drupal.org/project/geofield/issues/3492426#comment-15937239 )

leaflet patch has been merged into dev (see https://www.drupal.org/project/leaflet/issues/3498789#comment-15937884 )

there's a commit on addressing by NDW that was merged also see https://github.com/commerceguys/addressing/pull/221

[Addendum: these fixes going into dev was not important - that they had actual releases was, however, but the fix remained the same]