### PR TITLE
fix: set workflow back to 1.x branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@feature/1.x/d11-support
+    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x
     with:
       project: 'localgovdrupal/localgov_geo'
       project_path: 'web/modules/contrib/localgov_geo'


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Set the workflow back to `1.x` branch now that the D11 testing has been merged